### PR TITLE
Explain use and updates to tools in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.9.0
 LABEL maintainer="Guinevere Saenger <guineveresaenger@gmail.com>"
 
-# ENV GODEP_VERSION v79
-# ENV GODEP_URL https://github.com/tools/godep/releases/download/$GODEP_VERSION/godep_linux_amd64
-# ENV GODEP_SHA256SUM "d67903869dfb994d9bc627cba7314628eb398679232b27ea2bba66b08cd59cfb  /usr/local/bin/godep"
+ENV GODEP_VERSION v79
+ENV GODEP_URL https://github.com/tools/godep/releases/download/$GODEP_VERSION/godep_linux_amd64
+ENV GODEP_SHA256SUM "d67903869dfb994d9bc627cba7314628eb398679232b27ea2bba66b08cd59cfb  /usr/local/bin/godep"
 
 ENV GOSU_VERSION 1.10
 ENV GOSU_URL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64
@@ -13,10 +13,9 @@ ENV GOSU_PATH /usr/local/bin/gosu
 
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 
-# RUN curl -sL "$GODEP_URL" -o /usr/local/bin/godep \
-# 	&& strip /usr/local/bin/godep \
-#     && echo $GODEP_SHA256SUM | sha256sum -c \
-#     && chmod 755 /usr/local/bin/godep
+RUN curl -sL "$GODEP_URL" -o /usr/local/bin/godep \
+	&& strip /usr/local/bin/godep \
+    && chmod 755 /usr/local/bin/godep
 
 RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 	&& curl -fsSL "$GOSU_URL.asc" -o "$GOSU_PATH.asc" \
@@ -24,12 +23,13 @@ RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 	&& rm "$GOSU_PATH.asc" \
 	&& chmod +x "$GOSU_PATH"
 
+ADD hello /go/src/hello
+
 RUN go get \
     golang.org/x/tools/cmd/godoc \
     golang.org/x/tools/cmd/goimports \
     github.com/golang/lint/golint \
-    honnef.co/go/tools/cmd/gosimple \
-    github.com/tools/godep 
+    honnef.co/go/tools/cmd/gosimple
 
 # entrypoint script to set the container user to host user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.9.0
 LABEL maintainer="Guinevere Saenger <guineveresaenger@gmail.com>"
+WORKDIR /go/src/app
 
 ENV DEP_VERSION v0.3.2
 ENV DEP_URL https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-linux-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src
 
 ENV DEP_VERSION v0.3.2
 ENV DEP_URL https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-linux-amd64
-ENV DEP_SHA256SUM "d67903869dfb994d9bc627cba7314628eb398679232b27ea2bba66b08cd59cfb  /usr/local/bin/godep"
+ENV DEP_SHA256SUM "7394a53bfe4c8ff30562f48fbecbdb3ef2cc28a140deebac0c992b371344132a  /usr/local/bin/dep"
 
 ENV GOSU_VERSION 1.10
 ENV GOSU_URL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64
@@ -16,7 +16,8 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364
 
 RUN curl -sL "$DEP_URL" -o /usr/local/bin/dep \
 	&& strip /usr/local/bin/dep \
-    && chmod 755 /usr/local/bin/dep
+    && chmod 755 /usr/local/bin/dep \
+	&& echo $DEP_SHA256SUM | sha256sum -c
 
 RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 	&& curl -fsSL "$GOSU_URL.asc" -o "$GOSU_PATH.asc" \
@@ -27,6 +28,10 @@ RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 RUN go get \
     golang.org/x/tools/cmd/godoc \
 	gopkg.in/alecthomas/gometalinter.v2
+
+RUN rm -rf /go/src/golang.org/x/tools/.git \
+	&& rm -rf /go/src/gopkg.in/alecthomas/gometalinter.v2/.git
+
 
 # entrypoint script to set the container user to host user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src
 
 ENV DEP_VERSION v0.4.1
 ENV DEP_URL https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-linux-amd64
-ENV DEP_SHA256SUM "7394a53bfe4c8ff30562f48fbecbdb3ef2cc28a140deebac0c992b371344132a  /usr/local/bin/dep"
+ENV DEP_SHA256SUM "b6b9a83f187e75284e1dc071f336baf8d7ab1554b7ca5c5b0b9af3d9bc12993a  /usr/local/bin/dep"
 
 ENV GOSU_VERSION 1.10
 ENV GOSU_URL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 	&& rm "$GOSU_PATH.asc" \
 	&& chmod +x "$GOSU_PATH"
 
-ADD hello /go/src/hello
-
 RUN go get \
     golang.org/x/tools/cmd/godoc \
     golang.org/x/tools/cmd/goimports \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,22 @@
 FROM golang:1.9.0
 LABEL maintainer="Guinevere Saenger <guineveresaenger@gmail.com>"
 
-ENV GODEP_VERSION v79
-ENV GODEP_URL https://github.com/tools/godep/releases/download/$GODEP_VERSION/godep_linux_amd64
-ENV GODEP_SHA256SUM "d67903869dfb994d9bc627cba7314628eb398679232b27ea2bba66b08cd59cfb  /usr/local/bin/godep"
+# ENV GODEP_VERSION v79
+# ENV GODEP_URL https://github.com/tools/godep/releases/download/$GODEP_VERSION/godep_linux_amd64
+# ENV GODEP_SHA256SUM "d67903869dfb994d9bc627cba7314628eb398679232b27ea2bba66b08cd59cfb  /usr/local/bin/godep"
 
 ENV GOSU_VERSION 1.10
 ENV GOSU_URL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64
 ENV GOSU_PATH /usr/local/bin/gosu
 
-#
-# Luckily golang container has curl and ca-certificates installed already, so we don't need apt-get for anything.
-# Just need to add in glide for golang dependency management.
-#
+# The golang container has curl and ca-certificates installed already, so we don't need apt-get for anything.
+
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 
-RUN curl -sL "$GODEP_URL" -o /usr/local/bin/godep \
-	&& strip /usr/local/bin/godep \
-    && echo $GODEP_SHA256SUM | sha256sum -c \
-    && chmod 755 /usr/local/bin/godep
+# RUN curl -sL "$GODEP_URL" -o /usr/local/bin/godep \
+# 	&& strip /usr/local/bin/godep \
+#     && echo $GODEP_SHA256SUM | sha256sum -c \
+#     && chmod 755 /usr/local/bin/godep
 
 RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 	&& curl -fsSL "$GOSU_URL.asc" -o "$GOSU_PATH.asc" \
@@ -26,6 +24,12 @@ RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 	&& rm "$GOSU_PATH.asc" \
 	&& chmod +x "$GOSU_PATH"
 
+RUN go get \
+    golang.org/x/tools/cmd/godoc \
+    golang.org/x/tools/cmd/goimports \
+    github.com/golang/lint/golint \
+    honnef.co/go/tools/cmd/gosimple \
+    github.com/tools/godep 
 
 # entrypoint script to set the container user to host user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.9.0
 LABEL maintainer="Guinevere Saenger <guineveresaenger@gmail.com>"
 
-ENV GODEP_VERSION v79
-ENV GODEP_URL https://github.com/tools/godep/releases/download/$GODEP_VERSION/godep_linux_amd64
-ENV GODEP_SHA256SUM "d67903869dfb994d9bc627cba7314628eb398679232b27ea2bba66b08cd59cfb  /usr/local/bin/godep"
+ENV DEP_VERSION v0.3.2
+ENV DEP_URL https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-linux-amd64
+ENV DEP_SHA256SUM "d67903869dfb994d9bc627cba7314628eb398679232b27ea2bba66b08cd59cfb  /usr/local/bin/godep"
 
 ENV GOSU_VERSION 1.10
 ENV GOSU_URL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64
@@ -13,9 +13,9 @@ ENV GOSU_PATH /usr/local/bin/gosu
 
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 
-RUN curl -sL "$GODEP_URL" -o /usr/local/bin/godep \
-	&& strip /usr/local/bin/godep \
-    && chmod 755 /usr/local/bin/godep
+RUN curl -sL "$DEP_URL" -o /usr/local/bin/dep \
+	&& strip /usr/local/bin/dep \
+    && chmod 755 /usr/local/bin/dep
 
 RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 	&& curl -fsSL "$GOSU_URL.asc" -o "$GOSU_PATH.asc" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.0
+FROM golang:1.9.2
 LABEL maintainer="Guinevere Saenger <guineveresaenger@gmail.com>"
 WORKDIR /go/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.9.0
 LABEL maintainer="Guinevere Saenger <guineveresaenger@gmail.com>"
-WORKDIR /go/src/app
+WORKDIR /go/src
 
 ENV DEP_VERSION v0.3.2
 ENV DEP_URL https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-linux-amd64
@@ -26,9 +26,7 @@ RUN curl -L "$GOSU_URL" -o "$GOSU_PATH" \
 
 RUN go get \
     golang.org/x/tools/cmd/godoc \
-    golang.org/x/tools/cmd/goimports \
-    github.com/golang/lint/golint \
-    honnef.co/go/tools/cmd/gosimple
+	gopkg.in/alecthomas/gometalinter.v2
 
 # entrypoint script to set the container user to host user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.9.2
 LABEL maintainer="Guinevere Saenger <guineveresaenger@gmail.com>"
 WORKDIR /go/src
 
-ENV DEP_VERSION v0.3.2
+ENV DEP_VERSION v0.4.1
 ENV DEP_URL https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-linux-amd64
 ENV DEP_SHA256SUM "7394a53bfe4c8ff30562f48fbecbdb3ef2cc28a140deebac0c992b371344132a  /usr/local/bin/dep"
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ Verify the go version:
 
 To run or build  your tool with the container, run 
 
-`docker run --rm -v ${go_dir}:/go -w /go${build_dir} quay.io/samsung_cnct/golang-container:latest go build <mytool>`
+`docker run --rm -v ${go_dir}:/go -w /go${build_dir} quay.io/samsung_cnct/golang-container:latest go build <mytool.go>`
 
-This will build a golang binary inside the build container and place it (via the mounted volume) into your current local directory. Be aware that unless your local environment is a Linux environment, this binary cannot execute.
+This will build a golang binary inside the build container and place it (via the mounted volume) into your current local directory. 
 
+*Special instructions for cross-compilation to OSX*
+Be aware that unless your local environment is a Linux environment, the above built binary cannot execute on a Mac. You must pass env variables telling the build to build for the OSX environment.
+
+`docker run --rm -v ${go_dir}:/go -w /go${build_dir} quay.io/samsung_cnct/golang-container:latest env GOOS=darwin GOARCH=amd64 go build <mytool.go>`
+
+Reference for the golang DockerHub container, including cross-compilation instructions, can be found [here](https://hub.docker.com/_/golang/)

--- a/README.md
+++ b/README.md
@@ -10,4 +10,26 @@ The intended use for this container is as a build container for solas-apps (comi
 
 The original golang image is from the [Docker Hub golang image](https://hub.docker.com/_/golang/).
 
-For greater understanding of how this container works, you can use it locally to build a golang program as follows:
+For greater understanding of how this container works, you can use it locally on your Mac, or from inside another container, to build a golang program as follows:
+
+1. Navigate to your golang project's folder.
+
+2. Create two bash variables:
+    1. `go_dir=<your local gopath>`
+    2. `build_dir=<the path from the go directory to your current working directory, starting with /src>`
+    You will need these variable to mount a volume to the container, and then tell the container which directory to build in.
+
+3. To run the container, the basic command will then look like this:
+
+    `docker run --rm -v ${go_dir}:/go -w /go${build_dir} quay.io/samsung_cnct/golang-container:latest`
+
+Verify the go version:
+
+`docker run --rm -v ${go_dir}:/go -w /go${build_dir} quay.io/samsung_cnct/golang-container:latest go version`
+
+To run or build  your tool with the container, run 
+
+`docker run --rm -v ${go_dir}:/go -w /go${build_dir} quay.io/samsung_cnct/golang-container:latest go build <mytool>`
+
+This will build a golang binary inside the build container and place it (via the mounted volume) into your current local directory. Be aware that unless your local environment is a Linux environment, this binary cannot execute.
+

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install all linters via gometalinter:
     - gometalinter.v2 --install
 ```
 
-Add your dependencies with `dep`:
+Note: if your code has no checked in dependencies, you can add them with `dep init`; otherwise run `dep ensure` to check for differences between your Gopkg.lock and Gopkg.toml - documentation [here](https://github.com/golang/dep#usage)
 
 ```
 (script:)
@@ -53,7 +53,7 @@ Add your dependencies with `dep`:
 
 This setup should enable you to run all the standard Go tools, including `go build`, in a standardized context.
 
-Finally, for use of the built golang project and/or binary in subsequent stages, create an artifact of the created files: 
+Finally, for use of the built golang project and/or binary in subsequent stages, create an [artifact] of the created files: 
 
 ```
 artifacts:

--- a/README.md
+++ b/README.md
@@ -4,4 +4,10 @@
 
 This is a container that provides a build environment for golang apps. It is ported from a golang tools repository found [here](https://github.com/samsung-cnct/golang-tools/tree/master/goglide-container).
 
-Undergoing construction; please stand by while documentation is being created.
+## How To Use
+
+The intended use for this container is as a build container for solas-apps (coming soon). It provides gosu with a standardized golang container, and an entrypoint.sh script that takes command line arguments.
+
+The original golang image is from the [Docker Hub golang image](https://hub.docker.com/_/golang/).
+
+For greater understanding of how this container works, you can use it locally to build a golang program as follows:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The intended use for this container is to provide a consistent golang test envir
 
 Gosu is used in the entrypoint.sh script to add a local user.
 
-The `dep` functionality is a flexible dependency manager that identifies the imported dependencies in the Golang code, imports them, and sets them in a `vendor` directory. This way, CI can run and test the Go code in any project inside this container. Dep is, per its creators, still in the experiemntal state, but it is actively being improved and developed, and is by far the best dependency management tool out there for CI purposes. The alternative, `godep`, would require each and every project to be checked in to CI with a `vendor` directory already created; `dep` creates one inside the golang container during each CI run.
+The `dep` functionality is a flexible dependency manager that identifies the imported dependencies in the Golang code, imports them, and sets them in a `vendor` directory. This way, CI can run and test the Go code in any project inside this container. Dep is, per its creators, still in the experimental state, but it is actively being improved and developed, and is by far the best dependency management tool out there for CI purposes. The alternative, `godep`, would require each and every project to be checked in to CI with a `vendor` directory already created; `dep` creates one inside the golang container during each CI run.
 
 The original golang image is from the [Docker Hub golang image](https://hub.docker.com/_/golang/).
 
@@ -32,11 +32,25 @@ script:
   - ln -s /samsung-cnct/<my_golang_project> /go/src/github.com && cd /go/src/github.com/<my_golang_project>
 ```
 
-Thereafter, you may execute any go tools desired.
+Add your dependencies with `dep`:
 
-Finally, for use of the built golang project and/or binary in subsequent stages, define an artifact to persist beyond the current stage.
+```
+(script:)
+    - ...
+    - dep init
+    - dep ensure
+```
 
-_Here is an example of a stage using the golang container:_
+Thereafter, you may execute any go tools desired including `go build`.
+
+Finally, for use of the built golang project and/or binary in subsequent stages, create an artifact of the created files: 
+
+```
+artifacts:
+    untracked: true
+```
+
+_Here is an example of a CI build stage using the golang container:_
 
 ```
 stages:
@@ -46,16 +60,15 @@ build:
   stage: build
   image: quay.io/samsung-cnct/golang-container:latest
   script:
-  - ln -s /samsung-cnct/<my_golang_project> /go/src/github.com && cd /go/src/github.com/<my_golang_project>
+  - ln -s /samsung-cnct/<golang_project> /go/src/github.com && cd /go/src/github.com/<golang_project>
   - dep init
   - dep ensure
-  - go vet -v <my_golang_project>.go
-  - golint <my_golang_project>.go
+  - go vet -v <golang_project>.go
+  - golint <golang_project>.go
   - go test
-  - go build /go/src/github.com/<my_golang_project>/<my_golang_project>.go
+  - go build /go/src/github.com/<golang_project>/<golang_project>.go
   artifacts:
-    paths:
-      - /samsung-cnct/<my_golang_project>
+    untracked: true
 ```
 
 ## Use in local environment

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Gosu is used in the entrypoint.sh script to add a local user.
 
 The `dep` functionality is a flexible dependency manager that identifies the imported dependencies in the Golang code, imports them, and sets them in a `vendor` directory. This way, CI can run and test the Go code in any project inside this container. Dep is, per its creators, still in the experimental state, but it is actively being improved and developed, and is by far the best dependency management tool out there for CI purposes. The alternative, `godep`, would require each and every project to be checked in to CI with a `vendor` directory already created; `dep` creates one inside the golang container during each CI run.
 
+Additionally the container adds [godoc](https://godoc.org/golang.org/x/tools/cmd/godoc) as well as [gometalinter](https://github.com/alecthomas/gometalinter) to have access to testing tools.
+
 The original golang image is from the [Docker Hub golang image](https://hub.docker.com/_/golang/).
 
 
@@ -25,23 +27,31 @@ In your build and/or test stage, the golang container image can be set with the 
 image: quay.io/samsung-cnct/golang-container:latest
 ```
 
-Because CI places your files in the container's `samsung-cnct` directory, rather than in the container's GOPATH at `/go/src/github.com`, create a symlink into to the project, and change into the linked direcory:
+Because CI places your files in the container's `samsung-cnct` directory, rather than in the container's GOPATH at `/go/src/github.com`, create a symlink into to the project, and change into the linked directory:
 
 ```
 script:
   - ln -s /samsung-cnct/<my_golang_project> /go/src/github.com && cd /go/src/github.com/<my_golang_project>
 ```
 
+Install all linters via gometalinter:
+
+```
+(script:)
+    ...
+    - gometalinter.v2 --install
+```
+
 Add your dependencies with `dep`:
 
 ```
 (script:)
-    - ...
+    ...
     - dep init
     - dep ensure
 ```
 
-Thereafter, you may execute any go tools desired including `go build`.
+This setup should enable you to run all the standard Go tools, including `go build`, in a standardized context.
 
 Finally, for use of the built golang project and/or binary in subsequent stages, create an artifact of the created files: 
 
@@ -60,6 +70,7 @@ build:
   stage: build
   image: quay.io/samsung-cnct/golang-container:latest
   script:
+  - gometalinter.v2 --install
   - ln -s /samsung-cnct/<golang_project> /go/src && cd /go/src/<golang_project>
   - dep init
   - dep ensure

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ build:
   stage: build
   image: quay.io/samsung-cnct/golang-container:latest
   script:
-  - ln -s /samsung-cnct/<golang_project> /go/src/github.com && cd /go/src/github.com/<golang_project>
+  - ln -s /samsung-cnct/<golang_project> /go/src && cd /go/src/<golang_project>
   - dep init
   - dep ensure
   - go vet -v <golang_project>.go


### PR DESCRIPTION
This PR updates the golang container to contain `dep`, a useful dependency management tool, and outlines how to use it in CI and locally for research purposes.

ToReview:
- Comments on `curl` vs. `go get` in Dockerfile appreciated. Curl is used for the two main tools added for the main purpose of being able to choose a specific version. All other golang tools added use `go get`. 
- Any other tools that should live in the container? Any redundancies?
- Does the explanation for CI in README make sense?